### PR TITLE
JuliaCon 2020 session proposals

### DIFF
--- a/conferences/README.md
+++ b/conferences/README.md
@@ -6,3 +6,4 @@ This folder contains resources relating to conferences Sarah applied to or atten
 | --- | --- | --- | --- | --- |
 | 2020 SSI Fellows Inaugural Meeting | 11th February 2020 | University of Manchester, UK | | [inaugural_meeting_intro_slides.pdf](presentations/inaugural_meeting_intro_slides.pdf) |
 | [European R Users Meeting 2020](https://2020.erum.io/) | 27th - 30th May 2020 | University of Milano-Bicocca, Politecnico Milano, Italy | [abstract submission](abstracts/eRum2020.md) | |
+|[JuliaCon 2020](https://juliacon.org/2020/) | 27th - 31st July 2020 | ISCTE - Instituto Universitário de Lisboa (ISCTE-IUL), Portugal | [lightning talk proposal](abstracts/JuliaCon2020-lightning-talk.md) | |

--- a/conferences/README.md
+++ b/conferences/README.md
@@ -6,4 +6,4 @@ This folder contains resources relating to conferences Sarah applied to or atten
 | --- | --- | --- | --- | --- |
 | 2020 SSI Fellows Inaugural Meeting | 11th February 2020 | University of Manchester, UK | | [inaugural_meeting_intro_slides.pdf](presentations/inaugural_meeting_intro_slides.pdf) |
 | [European R Users Meeting 2020](https://2020.erum.io/) | 27th - 30th May 2020 | University of Milano-Bicocca, Politecnico Milano, Italy | [abstract submission](abstracts/eRum2020.md) | |
-|[JuliaCon 2020](https://juliacon.org/2020/) | 27th - 31st July 2020 | ISCTE - Instituto Universitário de Lisboa (ISCTE-IUL), Portugal | [lightning talk proposal](abstracts/JuliaCon2020-lightning-talk.md) | |
+|[JuliaCon 2020](https://juliacon.org/2020/) | 27th - 31st July 2020 | ISCTE - Instituto Universitário de Lisboa (ISCTE-IUL), Portugal | [lightning talk proposal](abstracts/JuliaCon2020-lightning-talk.md), [birds of feather proposal](abstracts/JuliaCon2020-BoF.md) | |

--- a/conferences/abstracts/JuliaCon2020-BoF.md
+++ b/conferences/abstracts/JuliaCon2020-BoF.md
@@ -1,0 +1,42 @@
+# JuliaCon 2020 Proposal - Birds of a Feather
+
+**Where:** ISCTE - Instituto Universitário de Lisboa (ISCTE-IUL), Portugal
+
+**When:** 27th - 31st July 2020
+
+**Conference website:** <https://juliacon.org/2020/>
+
+**Call for Proposals website:** <https://pretalx.com/juliacon2020/cfp>
+
+## Submission Title
+
+Project Binder and the Julia Community: Planning for the Future
+
+## Submission Type
+
+Birds of Feather (60 minutes)
+
+## Abstract
+
+_At most 500 characters._
+
+_Current character count: 461_
+
+This Birds of Feather session aims to facilitate structured discussion around some of the themes that arose from the mybinder.org user survey (https://mybinder.org).
+Specifically, which features or improvements would the Julia community like the Project Binder team (https://jupyter.org/binder) to pursue, what roadblocks do they foresee, and what "on ramps" are available for community members to become involved in the development and implementation processes.
+
+## Description
+
+_Optional. At most 2500 characters._
+
+_Current character count: 1,345_
+
+The Binder Project is a collection of tools that rewards best practices in reproducible data science and provides an easy method of sharing computing environments with anyone via a single clickable link.
+The free and public Binder service, hosted at https://mybinder.org, serves around 100,000 launches per week from over 10,000 individual git repositories in a variety of programming languages, including Julia.
+
+Binder is a community-driven project, taking the lead from community-developed standards of reproducibility and input from its users via the mybinder.org user survey.
+The user survey was last conducted at the beginning of 2020 and a summary of the results, both general and specific to the Julia community, will be presented.
+
+There are so many fantastic ideas and features the Binder project team (https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team) would like to develop but - like many open source projects - we face time restrictions, a low bus factor (https://en.wikipedia.org/wiki/Bus_factor), and often lack domain expertise when developing language-specific features.
+
+Sarah Gibson would like to introduce the Binder Project to the Julia community as an opportunity to shape a tool that would be most useful to them and provide guidance on how to get started with contributing to or joining the project.

--- a/conferences/abstracts/JuliaCon2020-lightning-talk.md
+++ b/conferences/abstracts/JuliaCon2020-lightning-talk.md
@@ -30,7 +30,7 @@ She will introduce herself as a point of contact for further discussion on how t
 
 _Optional. At most 2500 characters._
 
-_Current character count: 1,497_
+_Current character count: 1,501_
 
 The Binder Project is a collection of tools that rewards best practices in reproducible data science and provides an easy method of sharing computing environments with anyone via a single clickable link.
 The free and public Binder service, hosted at https://mybinder.org, serves around 100,000 launches per week from over 10,000 individual git repositories in a variety of programming languages, including Julia.
@@ -42,4 +42,4 @@ There are so many fantastic ideas and features the Binder project team (https://
 
 Sarah Gibson would like to introduce the Binder Project to the Julia community as an opportunity to shape a tool that would be most useful to them and provide guidance on how to get started with contributing to or joining the project.
 
-This lightning talk will (hopefully!) be accompanied by a Birds of a Feather session or a drop-in table where Sarah will be available for more in-depth discussions about Binder.
+This lightning talk will (hopefully!) be accompanied by a Birds of a Feather session and/or a drop-in table where Sarah will be available for more in-depth discussions about Binder.

--- a/conferences/abstracts/JuliaCon2020-lightning-talk.md
+++ b/conferences/abstracts/JuliaCon2020-lightning-talk.md
@@ -1,0 +1,45 @@
+# JuliaCon 2020 Proposal - Lightning Talk
+
+**Where:** ISCTE - Instituto Universitário de Lisboa (ISCTE-IUL), Portugal
+
+**When:** 27th - 31st July 2020
+
+**Conference website:** <https://juliacon.org/2020/>
+
+**Call for Proposals website:** <https://pretalx.com/juliacon2020/cfp>
+
+## Submission Title
+
+Project Binder and the Julia Community: How can we help each other?
+
+## Submission Type
+
+Lightning Talk (10 minutes)
+
+## Abstract
+
+_At most 500 characters._
+
+_Current character count: 500_
+
+Project Binder (https://mybinder.org, https://jupyter.org/binder) offers an easy place to share reproducible computing environments, including Julia.
+In this lightning talk, Sarah Gibson will present the results of the mybinder.org User Survey, in particular those of interest to or suggested by the Julia community.
+She will introduce herself as a point of contact for further discussion on how the Julia and Binder communities can work more closely, and how you can become involved in Project Binder.
+
+## Description
+
+_Optional. At most 2500 characters._
+
+_Current character count: 1,505_
+
+The Binder Project is a collection of tools that rewards best practices in reproducible data science and provides an easy method of sharing computing environments with anyone via a single clickable link.
+The free and public Binder service, hosted at https://mybinder.org, serves around 100,000 launches per week from over 10,000 individual git repositories in a variety of programming languages, including Julia.
+
+Binder is a community-driven project, taking the lead from community-developed standards of reproducibility and input from its users via the mybinder.org user survey.
+The user survey was last conducted at the beginning of 2020 and a summary of the results will be presented during the lightning talk.
+
+There are so many fantastic ideas and features the Binder project team (https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team) would like to develop but - like many open source projects - we face time restrictions, a low bus factor (https://en.wikipedia.org/wiki/Bus_factor), and often lack domain expertise when developing language-specific features.
+
+Sarah Gibson would like to introduce the Binder Project to the Julia community as an opportunity to shape a tool that would be most useful to them and provide guidance on how to get started with contributing to or joining the project.
+
+This lightning talk will (hopefully!) be accompanied by a Birds of a Feather session or a drop-in table where Sarah will be available for more in-depth discussions on particular topics.

--- a/conferences/abstracts/JuliaCon2020-lightning-talk.md
+++ b/conferences/abstracts/JuliaCon2020-lightning-talk.md
@@ -30,7 +30,7 @@ She will introduce herself as a point of contact for further discussion on how t
 
 _Optional. At most 2500 characters._
 
-_Current character count: 1,505_
+_Current character count: 1,497_
 
 The Binder Project is a collection of tools that rewards best practices in reproducible data science and provides an easy method of sharing computing environments with anyone via a single clickable link.
 The free and public Binder service, hosted at https://mybinder.org, serves around 100,000 launches per week from over 10,000 individual git repositories in a variety of programming languages, including Julia.
@@ -42,4 +42,4 @@ There are so many fantastic ideas and features the Binder project team (https://
 
 Sarah Gibson would like to introduce the Binder Project to the Julia community as an opportunity to shape a tool that would be most useful to them and provide guidance on how to get started with contributing to or joining the project.
 
-This lightning talk will (hopefully!) be accompanied by a Birds of a Feather session or a drop-in table where Sarah will be available for more in-depth discussions on particular topics.
+This lightning talk will (hopefully!) be accompanied by a Birds of a Feather session or a drop-in table where Sarah will be available for more in-depth discussions about Binder.


### PR DESCRIPTION
## Summary

This PR adds proposals for a lightning talk and birds of feather session at JuliaCon 2020 to the repo. I have used the "Description" section of the form to add more detail to the proposals (a 500 character abstract was quite a squeeze!). As far as I'm aware, these descriptions will be made available to the attendees as well.

**Deadline: 7th March 2020**

Related issues: #7 

## What's changed?

- lightning talk proposal added to conferences/abstracts
- birds of feather proposal added to conferences/abstracts
- conferences/readme updated

## What should a reviewer focus they're feedback on?

- [ ] Everything looks ok?
- [ ] Language/spelling/grammar
- [ ] Room for improvement or increased impact in terms of being a "great" proposal?

## Who can help?

- @willingc